### PR TITLE
Round to nearest byte

### DIFF
--- a/src/BitPacker/BitWriter.cs
+++ b/src/BitPacker/BitWriter.cs
@@ -11,11 +11,12 @@ namespace BitPacker
 
 		public byte[] ToBytes()
 		{
+			var finalSize = _buffer.Count * sizeof(uint) + ((_scratchBits + 8 - 1) / 8);
 			if (_scratchBits > 0)
 			{
 				Flush();
 			}
-			var result = new byte[_buffer.Count * sizeof(uint)];
+			var result = new byte[finalSize];
 			Buffer.BlockCopy(_buffer.ToArray(), 0, result, 0, result.Length);
 			return result;
 		}

--- a/tests/BitPacker.Tests/SerializationTests.cs
+++ b/tests/BitPacker.Tests/SerializationTests.cs
@@ -21,11 +21,11 @@ public class UnitTest1
 
 		var arr = writer.ToBytes();
 
-		arr.Should().BeEquivalentTo(new[] { 0b11111111, 0, 0, 0 });
+		arr.Should().BeEquivalentTo(new[] { 0b11111111 });
 	}
 
 	[Theory]
-	//[InlineData(10, 0, 100)]
+	[InlineData(10, 0, 100)]
 	[InlineData(4900000000, 0, 5000000000)]
 	public void ReadLong(long value, long min, long max)
 	{


### PR DESCRIPTION
When writing, do not round up to the nearest doubleword, round up to the nearest byte.